### PR TITLE
updates: spectrum paths, documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,35 +3,32 @@
 ## Status
 
 Work in progress to adapt device specific out-of-tree build configs for Spectrum OS
+Basic structure for out-of-tree build configuration, referring to Spectrum in place.
 
 ## Usage with Spectrum upstream
 
 ### Setup repositories
 
-    $ git clone https://spectrum-os.org/git/spectrum
-    $ git clone -b rootfs https://spectrum-os.org/git/nixpkgs
-    $ git clone https://github.com/tiiuae/spectrum-config-imx8
+    git clone https://spectrum-os.org/git/spectrum # upstream as is
+    git clone -b aarch64-imx8-crosscompile https://github.com/tiiuae/nixpkgs-spectrum.git # for imx8 uboot
+    git clone https://github.com/tiiuae/spectrum-config-imx8
 
 ### Build image - NOTE: does not work yet
 
-    $ export NIX_PATH=$NIX_PATH:spectrum-config=$(pwd)/spectrum-config-imx8/config.nix
-    $ cp -r spectrum-config-imx8/imx8qxp spectrum/img/
-    $ nix-build spectrum/img/imx8qxp/ -I nixpkgs=nixpkgs-spectrum
+    export NIX_PATH=$NIX_PATH:spectrum-config=$(pwd)/spectrum-config-imx8/config.nix
+    nix-build spectrum-config-imx8/imx8qxp/ -I nixpkgs=nixpkgs-spectrum/
 
 ### Known issues
 
-fails with:
-    ...
-    error: attribute 'ubootIMX8QXP' missing
+error: attribute 'rootfs' missing
 
-       at /home/vilvo/out-of-tree-build/spectrum/img/imx8qxp/default.nix:6:11:
+       at /home/vilvo/out-of-tree-build/spectrum-config-imx8/imx8qxp/default.nix:9:12:
 
-            5| let
-            6|   uboot = pkgs.ubootIMX8QXP;
-             |           ^
-            7|   spectrum = import ../live { };
-
-remedy: use aarch64-imx8-crosscompile branch from tiiuae/nixpkgs-spectrum
+            8|   spectrum = import ../../spectrum/img/live { };
+            9|   kernel = spectrum.rootfs.kernel;
+             |            ^
+           10| in
+(use '--show-trace' to show detailed location information)
 
 ## More info
 

--- a/config.nix
+++ b/config.nix
@@ -1,11 +1,11 @@
 {
   pkgs = import <nixpkgs> {
-    overlays = [(
-      self: super:
-      {
-        kernel = super.linux_imx8.override {};
-      }
-    )];
+    overlays = [
+      (self: super:
+        {
+          kernel = super.linux_imx8.override {};
+        })
+    ];
     crossSystem = { config = "aarch64-unknown-linux-musl"; };
   };
 }

--- a/imx8qxp/default.nix
+++ b/imx8qxp/default.nix
@@ -1,11 +1,11 @@
 # SPDX-FileCopyrightText: 2022 Unikie
 
-{ config ? import ../../nix/eval-config.nix {} }:
+{ config ? import ../../spectrum/nix/eval-config.nix {} }:
 
 let
   inherit (config) pkgs;
   uboot = pkgs.ubootIMX8QXP;
-  spectrum = import ../live { };
+  spectrum = import ../../spectrum/img/live { };
   kernel = spectrum.rootfs.kernel;
 in
 


### PR DESCRIPTION
* paths: update paths to spectrum with the assumption of this repo cloned next to spectrum - see "Setup repositories"
* doc: do not copy the build config under spectrun but use from where it is - out-of-tree
* doc: clone aarch64-imx8-crosscompile branch of nixpkgs-spectrum fork with imx8 uboot support. imx8 uboot support likely to remain in fork as not upstreamable to nixpkgs nor spectrum as vendor specific - maybe later to nix hardware-modules - https://github.com/NixOS/nixos-hardware - but would require spectrum build/installer support for it
* doc: update known issue with progress

Signed-off-by: Ville Ilvonen <ville.ilvonen@unikie.com>