### PR TITLE
Enable imx8 kernel via configuration layout

### DIFF
--- a/config.nix
+++ b/config.nix
@@ -3,7 +3,20 @@
     overlays = [
       (self: super:
         {
-          kernel = super.linux_imx8.override {};
+          linux_latest = super.linuxKernel.kernels.linux_imx8.override {
+            structuredExtraConfig = with self.lib.kernel; {
+              ATA_PIIX = yes;
+              EFI_STUB = yes;
+              EFI = yes;
+              VIRTIO = yes;
+              VIRTIO_PCI = yes;
+              VIRTIO_BLK = yes;
+              EXT4_FS = yes;
+            };
+          };
+          makeModulesClosure = args: super.makeModulesClosure (args // {
+            rootModules = [ "dm-verity" "loop" ];
+          });
         })
     ];
     crossSystem = { config = "aarch64-unknown-linux-musl"; };


### PR DESCRIPTION
redefenition of makeModulesClosure resolves build blocker and, also, allow to get rid from default set of kernel modules check adding own set of modules presence of which need to be verified.

It definetily not the best way of doing - proper way is to define several hardware profiles with possibility to be chosen from config layout.

Signed-off-by: Grigoriy Romanov <grigoriy.romanov@unikie.com>