### PR TITLE
imx8qxp/default.nix: fix base image's path

### DIFF
--- a/imx8qxp/default.nix
+++ b/imx8qxp/default.nix
@@ -5,7 +5,7 @@
 let
   inherit (config) pkgs;
   uboot = pkgs.ubootIMX8QXP;
-  spectrum = import ../../spectrum/img/live { };
+  spectrum = import ../../spectrum/release/live { };
   kernel = spectrum.rootfs.kernel;
 in
 


### PR DESCRIPTION
Signed-off-by: Ivan Nikolaenko <ivan.nikolaenko@unikie.com>