### PR TITLE
Don't override linux_latest with linux_imx8

### DIFF
--- a/config.nix
+++ b/config.nix
@@ -3,17 +3,6 @@
     overlays = [
       (self: super:
         {
-          linux_latest = super.linuxKernel.kernels.linux_imx8.override {
-            structuredExtraConfig = with self.lib.kernel; {
-              ATA_PIIX = yes;
-              EFI_STUB = yes;
-              EFI = yes;
-              VIRTIO = yes;
-              VIRTIO_PCI = yes;
-              VIRTIO_BLK = yes;
-              EXT4_FS = yes;
-            };
-          };
           makeModulesClosure = args: super.makeModulesClosure (args // {
             rootModules = [ "dm-verity" "loop" ];
           });


### PR DESCRIPTION
We can't override linux_latest beacause it's used by app vms which require at least kernel version 5.16 but linux_imx8 is 5.15.

Signed-off-by: Yuri Nesterov <yuriy.nesterov@unikie.com>