### PR TITLE
Add missing configuration options for linux_imx8 kernel

### DIFF
--- a/config.nix
+++ b/config.nix
@@ -3,6 +3,17 @@
     overlays = [
       (self: super:
         {
+          linux_imx8 = super.linuxKernel.kernels.linux_imx8.override {
+            structuredExtraConfig = with self.lib.kernel; {
+              ATA_PIIX = yes;
+              EFI_STUB = yes;
+              EFI = yes;
+              VIRTIO = yes;
+              VIRTIO_PCI = yes;
+              VIRTIO_BLK = yes;
+              EXT4_FS = yes;
+            };
+          };
           makeModulesClosure = args: super.makeModulesClosure (args // {
             rootModules = [ "dm-verity" "loop" ];
           });


### PR DESCRIPTION
These options are required for running virtual machines using cloud-hypervisor.

Signed-off-by: Yuri Nesterov <yuriy.nesterov@unikie.com>